### PR TITLE
Shooter limit switch

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -50,6 +50,7 @@ public final class Constants {
         public static final int RIGHT_ENCODER_2 = 3;
         public static final int TOP_CLIMB_LIMIT = 4;
         public static final int BOTTOM_CLIMB_LIMIT = 5;
+        public static final int SHOOTER_TRACK_LIMIT = 6;
     }
     
     // Constants related to robot driving

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -56,12 +56,13 @@ public class RobotContainer {
 
   private ShooterSubsystem m_shooter = new ShooterSubsystem(
     CAN.INDEX_MOTOR,
-    CAN.FLYWHEEL_MOTOR, CAN.FLYWHEEL_MOTOR2
+    CAN.FLYWHEEL_MOTOR, CAN.FLYWHEEL_MOTOR2,
+    Digital.SHOOTER_TRACK_LIMIT
     );
   
   private IntakeSubsystem m_intake = new IntakeSubsystem(
     Pneumatics.INTAKE_EXTEND, Pneumatics.INTAKE_RETRACT, 
-    CAN.INTAKE_MOTOR
+    CAN.INTAKE_MOTOR, Digital.SHOOTER_TRACK_LIMIT
   );
 
   private HookSubsystem m_hook = new HookSubsystem(CAN.WINCH_MOTOR, Digital.TOP_CLIMB_LIMIT, Digital.BOTTOM_CLIMB_LIMIT);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -45,8 +45,6 @@ public class RobotContainer {
 
   private DigitalInput shooter_track_limit = new DigitalInput(Digital.SHOOTER_TRACK_LIMIT);
 
-  private boolean isShooting = false;
-
   /* Contstructor for subsystems */
   private DrivebaseSubsystem m_drivebase = new DrivebaseSubsystem(
     CAN.LEFT_MOTOR_1, CAN.LEFT_MOTOR_2,
@@ -136,14 +134,22 @@ public class RobotContainer {
     .whenPressed(() -> m_drivebase.setScale(0.5))
     .whenReleased(() -> m_drivebase.setScale(1));  // Sets drivebase to half speed, for more precise and slow movement (likely going to be used inside hangar)
  
-    new JoystickButton(m_xboxController, XboxController.Button.kRightBumper.value)
-    .whenPressed(new InstantCommand(() -> m_shooter.spinFlywheel(flywheelSpeed.getDouble(0.8)), m_shooter))
-    .whenReleased(new InstantCommand(() -> m_shooter.spinFlywheel(0), m_shooter));  // Spins flywheel for shooter
+    new JoystickButton(m_xboxController, XboxController.Button.kRightBumper.value) // Drops intake, spins intake wheels and feeder wheels
+    .whenPressed(() -> {
+      m_shooter.setShootStatus(true);
+      m_feeder.setShootStatus(true);
+      m_shooter.spinFlywheel(flywheelSpeed.getDouble(0.8));
+    })
+    .whenReleased(() -> {
+      m_shooter.spinFlywheel(0);
+      m_shooter.setShootStatus(false);
+      m_feeder.setShootStatus(false);
+    });
 
     new JoystickButton(m_xboxController, XboxController.Button.kY.value) // Feeds ball to flywheel, spinning feeder and indexer wheels
     .whenPressed(new InstantCommand(() -> {
-      m_shooter.spinIndex(indexSpeed.getDouble(0.3));
-      m_feeder.spinFeeder(feederSpeed.getDouble(0.4));
+      m_shooter.spinIndex(-indexSpeed.getDouble(0.3));
+      m_feeder.spinFeeder(-feederSpeed.getDouble(0.4));
     }, m_shooter, m_feeder))
     .whenReleased(new InstantCommand(() -> {
       m_shooter.spinIndex(0);
@@ -187,7 +193,6 @@ public class RobotContainer {
       m_feeder.spinFeeder(0);
       m_intake.spin(0);
     });
-
 
     new Button(() -> {return m_xboxController.getPOV() == 0;})  // Extends hook up
       .whenPressed(() -> m_hook.extend(hookSpeed.getDouble(0.8)))

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -107,7 +107,7 @@ public class RobotContainer {
         tab.add("Auto Distance", 50) // specify widget properties here
             .getEntry();
 
-  public final Command m_autoCommand = new AutonomousCmdList(m_drivebase, m_shooter, m_feeder, autoDistance.getDouble(50), autoSpeed.getDouble(0.5)); //pass in drivebase here
+  public final Command m_autoCommand = new AutonomousCmdList(m_drivebase, m_shooter, m_feeder, autoDistance, autoSpeed, flywheelSpeed, indexSpeed, feederSpeed); //pass in drivebase here
 
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -22,6 +22,7 @@ import edu.wpi.first.wpilibj2.command.button.Button;
 import java.util.Map;
 
 import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.GenericHID;
 import frc.robot.commands.AutonomousCmdList;
 import frc.robot.subsystems.IntakeSubsystem;
@@ -42,6 +43,9 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 public class RobotContainer {
   // The robot's subsystems and commands are defined here...
 
+  private DigitalInput shooter_track_limit = new DigitalInput(Digital.SHOOTER_TRACK_LIMIT);
+
+  private boolean isShooting = false;
 
   /* Contstructor for subsystems */
   private DrivebaseSubsystem m_drivebase = new DrivebaseSubsystem(
@@ -52,17 +56,16 @@ public class RobotContainer {
   );
 
   //private FeederSubsystem m_feeder = new FeederSubsystem(CAN.FEEDER_MOTOR, CAN.FEEDER_MOTOR2);
-  private FeederSubsystem m_feeder = new FeederSubsystem(CAN.FEEDER_MOTOR);
+  private FeederSubsystem m_feeder = new FeederSubsystem(CAN.FEEDER_MOTOR, shooter_track_limit);
 
   private ShooterSubsystem m_shooter = new ShooterSubsystem(
     CAN.INDEX_MOTOR,
-    CAN.FLYWHEEL_MOTOR, CAN.FLYWHEEL_MOTOR2,
-    Digital.SHOOTER_TRACK_LIMIT
+    CAN.FLYWHEEL_MOTOR, CAN.FLYWHEEL_MOTOR2, shooter_track_limit
     );
   
   private IntakeSubsystem m_intake = new IntakeSubsystem(
     Pneumatics.INTAKE_EXTEND, Pneumatics.INTAKE_RETRACT, 
-    CAN.INTAKE_MOTOR, Digital.SHOOTER_TRACK_LIMIT
+    CAN.INTAKE_MOTOR
   );
 
   private HookSubsystem m_hook = new HookSubsystem(CAN.WINCH_MOTOR, Digital.TOP_CLIMB_LIMIT, Digital.BOTTOM_CLIMB_LIMIT);

--- a/src/main/java/frc/robot/commands/AutonomousCmdList.java
+++ b/src/main/java/frc/robot/commands/AutonomousCmdList.java
@@ -1,5 +1,6 @@
 package frc.robot.commands;
 
+import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import frc.robot.subsystems.DrivebaseSubsystem;
@@ -16,9 +17,9 @@ public class AutonomousCmdList extends SequentialCommandGroup {
    * @param drivedistance Set to distance in inches
    * @param driveSpeed Set to speed from -1 to 1 (must match sign of distance)
    */
-    public AutonomousCmdList(DrivebaseSubsystem m_drivebase, ShooterSubsystem m_shooter, FeederSubsystem m_feeder, double driveDistance, double driveSpeed) {
+    public AutonomousCmdList(DrivebaseSubsystem m_drivebase, ShooterSubsystem m_shooter, FeederSubsystem m_feeder, NetworkTableEntry driveDistance, NetworkTableEntry driveSpeed, NetworkTableEntry flywheelSpeed, NetworkTableEntry indexSpeed, NetworkTableEntry feederSpeed) {
         super();
-        this.addCommands(new ShootBall(m_shooter, m_drivebase, m_feeder));
+        this.addCommands(new ShootBall(m_shooter, m_drivebase, m_feeder, flywheelSpeed, indexSpeed, feederSpeed));
         this.addCommands(new DriveDistance(m_drivebase, driveDistance, driveSpeed));
     }
 }

--- a/src/main/java/frc/robot/commands/DriveDistance.java
+++ b/src/main/java/frc/robot/commands/DriveDistance.java
@@ -1,5 +1,6 @@
 package frc.robot.commands;
 
+import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
 import frc.robot.subsystems.DrivebaseSubsystem;
@@ -12,22 +13,21 @@ public class DriveDistance extends CommandBase {
 
   private DrivebaseSubsystem m_drivebase;
 
-  private double m_distance;
-  private double m_speed;
+  private NetworkTableEntry m_distance;
+  private NetworkTableEntry m_speed;
   /**
    * A command that spins the wheels for a certain distance
    * @param subsystem Set this to m_drivebase
    * @param distance Set to distance in inches
    * @param speed Set to speed from -1 to 1 (must match sign of distance)
    */
-  public DriveDistance(DrivebaseSubsystem subsystem, double distance, double speed) {
+  public DriveDistance(DrivebaseSubsystem subsystem, NetworkTableEntry distance, NetworkTableEntry speed) {
 
     m_drivebase = subsystem;
     m_distance = distance;
     m_speed = speed;
 
     addRequirements(m_drivebase);
-
   }
 
 
@@ -40,7 +40,7 @@ public class DriveDistance extends CommandBase {
   @Override
   public void execute() {
     // Sets the drivebase to go forward from the speed variable
-    m_drivebase.set(0, m_speed);
+    m_drivebase.set(0, m_speed.getDouble(0.5));
   }
 
 
@@ -50,10 +50,10 @@ public class DriveDistance extends CommandBase {
     double averageDistance = (m_drivebase.getLDistance() + m_drivebase.getRDistance()) / 2; 
     // This will say to end when the encoders are equal with the distance we want
 
-    if (m_speed < 0) {
-      return averageDistance <= m_distance;
+    if (m_speed.getDouble(0.5) < 0) {
+      return averageDistance <= m_distance.getDouble(50);
     } else {
-      return averageDistance >= m_distance;  
+      return averageDistance >= m_distance.getDouble(50);  
     }
   }
 

--- a/src/main/java/frc/robot/commands/ShootBall.java
+++ b/src/main/java/frc/robot/commands/ShootBall.java
@@ -1,5 +1,6 @@
 package frc.robot.commands;
 
+import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.DrivebaseSubsystem;
 import frc.robot.subsystems.FeederSubsystem;
@@ -11,6 +12,10 @@ public class ShootBall extends CommandBase{
   private FeederSubsystem m_feederSubsystem;
   private DrivebaseSubsystem m_drivebase;
   private int cycles = 0;
+
+  private NetworkTableEntry m_flywheelSpeed;
+  private NetworkTableEntry m_indexSpeed;
+  private NetworkTableEntry m_feederSpeed;
  
   /**
    * A command that shoots the ball once
@@ -19,7 +24,7 @@ public class ShootBall extends CommandBase{
    * @param feeder Set this to m_feederSubsystem 
    * drivebase is added as requirement so command delays without turning it on
    */
-   public ShootBall(ShooterSubsystem shooter, DrivebaseSubsystem drivebase, FeederSubsystem feeder){
+   public ShootBall(ShooterSubsystem shooter, DrivebaseSubsystem drivebase, FeederSubsystem feeder, NetworkTableEntry flywheelSpeed, NetworkTableEntry indexSpeed, NetworkTableEntry feederSpeed){
     
     m_drivebase = drivebase;
     m_shooterSubsystem = shooter;
@@ -27,6 +32,10 @@ public class ShootBall extends CommandBase{
     this.addRequirements(m_shooterSubsystem);
     this.addRequirements(m_drivebase);
     this.addRequirements(m_feederSubsystem);
+
+    m_flywheelSpeed = flywheelSpeed;
+    m_indexSpeed = indexSpeed;
+    m_feederSpeed = feederSpeed;
   }
 
   /**Makes sure that the cycles counter is 0
@@ -45,10 +54,10 @@ public class ShootBall extends CommandBase{
   @Override
   public void execute() {
     if (cycles >= 75) {
-      m_shooterSubsystem.spinIndex(-0.3);
-      m_feederSubsystem.spinFeeder(-0.4);
+      m_shooterSubsystem.spinIndex(m_flywheelSpeed.getDouble(-0.3));
+      m_feederSubsystem.spinFeeder(m_feederSpeed.getDouble(-0.4));
     }
-    m_shooterSubsystem.spinFlywheel(0.8);
+    m_shooterSubsystem.spinFlywheel(m_flywheelSpeed.getDouble(0.8));
     cycles++;
   }
 

--- a/src/main/java/frc/robot/commands/ShootBall.java
+++ b/src/main/java/frc/robot/commands/ShootBall.java
@@ -34,7 +34,9 @@ public class ShootBall extends CommandBase{
    */
   @Override
   public void initialize(){
-    cycles = 0; 
+    cycles = 0;
+    m_shooterSubsystem.setShootStatus(true);
+    m_feederSubsystem.setShootStatus(true);
   }
 
   /**Turns on all of the shooter motors
@@ -66,5 +68,7 @@ public class ShootBall extends CommandBase{
     m_shooterSubsystem.spinIndex(0);
     m_feederSubsystem.spinFeeder(0);
     m_shooterSubsystem.spinFlywheel(0);
+    m_shooterSubsystem.setShootStatus(false);
+    m_feederSubsystem.setShootStatus(false);
   }  
 }

--- a/src/main/java/frc/robot/subsystems/FeederSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/FeederSubsystem.java
@@ -15,34 +15,39 @@ public class FeederSubsystem extends SubsystemBase {
   private double m_feederPow = 0;
 
   private DigitalInput m_track_limit_switch;
+  private boolean m_shootStatus = false;
 
-/** Creates a new feederSubsystem. */
-public FeederSubsystem(int feederMotor, DigitalInput track_limit_switch) {
-  m_feeder = new CANSparkMax(feederMotor, MotorType.kBrushless);
-  //CANSparkMax feeder2 = new CANSparkMax(feederMotor2, MotorType.kBrushless);
-  m_feeder.setIdleMode(IdleMode.kBrake);
-  //feeder2.setIdleMode(IdleMode.kBrake);
-  //m_feeder = new MotorControllerGroup(feeder1, feeder2);
+  /** Creates a new feederSubsystem. */
+  public FeederSubsystem(int feederMotor, DigitalInput track_limit_switch) {
+    m_feeder = new CANSparkMax(feederMotor, MotorType.kBrushless);
+    //CANSparkMax feeder2 = new CANSparkMax(feederMotor2, MotorType.kBrushless);
+    m_feeder.setIdleMode(IdleMode.kBrake);
+    //feeder2.setIdleMode(IdleMode.kBrake);
+    //m_feeder = new MotorControllerGroup(feeder1, feeder2);
 
-  m_track_limit_switch = track_limit_switch;
-}
+    m_track_limit_switch = track_limit_switch;
+  }
 
-/**
- * Spins the feeder at a specified power level.
- * @param feedPow Speed to spin the feeder. -1 is full backwards, 1 is full forwards.
- */
-public void spinFeeder(double feedPow) {
-  m_feederPow = feedPow;
-}
+  /**
+   * Spins the feeder at a specified power level.
+   * @param feedPow Speed to spin the feeder. -1 is full backwards, 1 is full forwards.
+   */
+  public void spinFeeder(double feedPow) {
+    m_feederPow = feedPow;
+  }
 
-@Override
-public void periodic(){
-  //TODO figure out proper speed
-  if(!m_track_limit_switch.get()) {
-    m_feeder.set(.3);
-    System.out.println("");
-  } else {
-    m_feeder.set(m_feederPow);
-  } 
+  public void setShootStatus(boolean shootStatus) {
+    m_shootStatus = shootStatus;
+  }
+
+  @Override
+  public void periodic(){
+    //TODO figure out proper speed
+    if(!m_track_limit_switch.get() && !m_shootStatus) {
+      m_feeder.set(.1);
+      System.out.println("");
+    } else {
+      m_feeder.set(m_feederPow);
+    } 
   }
 }

--- a/src/main/java/frc/robot/subsystems/FeederSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/FeederSubsystem.java
@@ -45,7 +45,6 @@ public class FeederSubsystem extends SubsystemBase {
     //TODO figure out proper speed
     if(!m_track_limit_switch.get() && !m_shootStatus) {
       m_feeder.set(.1);
-      System.out.println("");
     } else {
       m_feeder.set(m_feederPow);
     } 

--- a/src/main/java/frc/robot/subsystems/FeederSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/FeederSubsystem.java
@@ -4,6 +4,7 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
+import edu.wpi.first.wpilibj.DigitalInput;
 //import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
@@ -13,13 +14,17 @@ public class FeederSubsystem extends SubsystemBase {
 
   private double m_feederPow = 0;
 
+  private DigitalInput m_track_limit_switch;
+
 /** Creates a new feederSubsystem. */
-public FeederSubsystem(int feederMotor) {
+public FeederSubsystem(int feederMotor, DigitalInput track_limit_switch) {
   m_feeder = new CANSparkMax(feederMotor, MotorType.kBrushless);
   //CANSparkMax feeder2 = new CANSparkMax(feederMotor2, MotorType.kBrushless);
   m_feeder.setIdleMode(IdleMode.kBrake);
   //feeder2.setIdleMode(IdleMode.kBrake);
   //m_feeder = new MotorControllerGroup(feeder1, feeder2);
+
+  m_track_limit_switch = track_limit_switch;
 }
 
 /**
@@ -32,6 +37,12 @@ public void spinFeeder(double feedPow) {
 
 @Override
 public void periodic(){
-  m_feeder.set(m_feederPow); 
+  //TODO figure out proper speed
+  if(!m_track_limit_switch.get()) {
+    m_feeder.set(.3);
+    System.out.println("");
+  } else {
+    m_feeder.set(m_feederPow);
+  } 
   }
 }

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -11,19 +11,25 @@ import edu.wpi.first.wpilibj.DoubleSolenoid.Value;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.Pneumatics;
 
+import edu.wpi.first.wpilibj.DigitalInput;
+
 public class IntakeSubsystem extends SubsystemBase {
   private DoubleSolenoid m_extend;
   private WPI_VictorSPX m_spin; 
   private boolean m_extended = false;
   private double m_speed = 0; 
 
+  private DigitalInput m_track_limit_switch;
+
   /** Creates a new IntakeSubsystem. */
   public IntakeSubsystem(
-    int intakeExtend, int intakeRetract, int intakeMotor
+    int intakeExtend, int intakeRetract, int intakeMotor, int track_limit_switch
   ){
     m_extend = new DoubleSolenoid(Pneumatics.PNEUMATICS_MODULE_TYPE, intakeExtend, intakeRetract);
     m_spin = new WPI_VictorSPX(intakeMotor);
   
+
+    m_track_limit_switch = new DigitalInput(track_limit_switch);
   }
 
   /**
@@ -81,6 +87,11 @@ public class IntakeSubsystem extends SubsystemBase {
 
   @Override
   public void periodic(){
-    m_spin.set(m_speed);
+    //TODO figure out proper speed
+    if(!m_track_limit_switch.get()){
+      m_spin.set(-.4);
+    } else {
+      m_spin.set(m_speed);
+    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -11,25 +11,19 @@ import edu.wpi.first.wpilibj.DoubleSolenoid.Value;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.Pneumatics;
 
-import edu.wpi.first.wpilibj.DigitalInput;
-
 public class IntakeSubsystem extends SubsystemBase {
   private DoubleSolenoid m_extend;
   private WPI_VictorSPX m_spin; 
   private boolean m_extended = false;
   private double m_speed = 0; 
 
-  private DigitalInput m_track_limit_switch;
 
   /** Creates a new IntakeSubsystem. */
   public IntakeSubsystem(
-    int intakeExtend, int intakeRetract, int intakeMotor, int track_limit_switch
+    int intakeExtend, int intakeRetract, int intakeMotor
   ){
     m_extend = new DoubleSolenoid(Pneumatics.PNEUMATICS_MODULE_TYPE, intakeExtend, intakeRetract);
     m_spin = new WPI_VictorSPX(intakeMotor);
-  
-
-    m_track_limit_switch = new DigitalInput(track_limit_switch);
   }
 
   /**
@@ -87,11 +81,6 @@ public class IntakeSubsystem extends SubsystemBase {
 
   @Override
   public void periodic(){
-    //TODO figure out proper speed
-    if(!m_track_limit_switch.get()){
-      m_spin.set(-.4);
-    } else {
-      m_spin.set(m_speed);
-    }
+    m_spin.set(m_speed);
   }
 }

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -21,6 +21,7 @@ public class ShooterSubsystem extends SubsystemBase {
   private double m_indexerPow = 0; 
 
   private DigitalInput m_track_limit_switch;
+  private boolean m_shootStatus = false;
 
   /** Creates a new ShooterSubsystem. */
   public ShooterSubsystem(
@@ -56,15 +57,23 @@ public class ShooterSubsystem extends SubsystemBase {
     m_indexerPow = indexPow;
   }
 
+  public void setShootStatus(boolean shootStatus) {
+    m_shootStatus = shootStatus;
+  }
+
+  public boolean getShootStatus() {
+    return m_shootStatus;
+  }
+
   @Override
   public void periodic() {
     // TODO Find proper speed for getting ball away from flywheel
-    if(!m_track_limit_switch.get()) {
-      m_indexer.set(.3);
-      System.out.println("");
+    if(!m_shootStatus && !m_track_limit_switch.get()) {
+      m_indexer.set(.2);
     } else {
-      m_flywheel.set(m_flywheelPow);
       m_indexer.set(m_indexerPow);
     }
+
+    m_flywheel.set(m_flywheelPow);
   }
 }

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -11,6 +11,8 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
+import edu.wpi.first.wpilibj.DigitalInput;
+
 public class ShooterSubsystem extends SubsystemBase {
   CANSparkMax m_indexer;
   MotorControllerGroup m_flywheel;
@@ -18,11 +20,13 @@ public class ShooterSubsystem extends SubsystemBase {
   private double m_flywheelPow = 0;
   private double m_indexerPow = 0; 
 
+  private DigitalInput m_track_limit_switch;
 
   /** Creates a new ShooterSubsystem. */
   public ShooterSubsystem(
     int indexMotor,
-    int flywheelMotor, int flywheelMotor2
+    int flywheelMotor, int flywheelMotor2,
+    int track_limit_switch
   ) {
     m_indexer = new CANSparkMax(indexMotor, MotorType.kBrushed);
     m_indexer.setIdleMode(IdleMode.kBrake);
@@ -32,6 +36,8 @@ public class ShooterSubsystem extends SubsystemBase {
     CANSparkMax flywheel1 = new CANSparkMax(flywheelMotor, MotorType.kBrushless);
     CANSparkMax flywheel2 = new CANSparkMax(flywheelMotor2, MotorType.kBrushless);
     m_flywheel = new MotorControllerGroup(flywheel1, flywheel2);
+
+    m_track_limit_switch = new DigitalInput(track_limit_switch);
   }
 
   /**
@@ -52,8 +58,12 @@ public class ShooterSubsystem extends SubsystemBase {
 
   @Override
   public void periodic() {
-    m_flywheel.set(m_flywheelPow);
-    m_indexer.set(m_indexerPow);
-   
+    // TODO Find proper speed for getting ball away from flywheel
+    if(!m_track_limit_switch.get()) {
+      m_indexer.set(-.4);
+    } else {
+      m_flywheel.set(m_flywheelPow);
+      m_indexer.set(m_indexerPow);
+    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -26,7 +26,7 @@ public class ShooterSubsystem extends SubsystemBase {
   public ShooterSubsystem(
     int indexMotor,
     int flywheelMotor, int flywheelMotor2,
-    int track_limit_switch
+    DigitalInput track_limit_switch
   ) {
     m_indexer = new CANSparkMax(indexMotor, MotorType.kBrushed);
     m_indexer.setIdleMode(IdleMode.kBrake);
@@ -37,7 +37,7 @@ public class ShooterSubsystem extends SubsystemBase {
     CANSparkMax flywheel2 = new CANSparkMax(flywheelMotor2, MotorType.kBrushless);
     m_flywheel = new MotorControllerGroup(flywheel1, flywheel2);
 
-    m_track_limit_switch = new DigitalInput(track_limit_switch);
+    m_track_limit_switch = track_limit_switch;
   }
 
   /**
@@ -60,7 +60,8 @@ public class ShooterSubsystem extends SubsystemBase {
   public void periodic() {
     // TODO Find proper speed for getting ball away from flywheel
     if(!m_track_limit_switch.get()) {
-      m_indexer.set(-.4);
+      m_indexer.set(.3);
+      System.out.println("");
     } else {
       m_flywheel.set(m_flywheelPow);
       m_indexer.set(m_indexerPow);


### PR DESCRIPTION
Limit switch inside of shooter track is now implemented in code. When the switch is hit, the feeder and indexer wheels spin back until the switch is released. When shooting (right bumper or auto) a boolean is flipped, deactivating the switch. After auto is done or shoot is released, the boolean is flipped back and the switch is reactivated. I also fixed the auto so its able to pull a new value from networktables every time it starts, allowing us to adjust the auto prior to the match from shuffleboard.